### PR TITLE
fix(bridge): resolve imported extra-extension files

### DIFF
--- a/patches/typescript-go/0001-bridge-inplace.patch
+++ b/patches/typescript-go/0001-bridge-inplace.patch
@@ -1457,7 +1457,7 @@ index 12b9d4079..db9750b1a 100644
  	return symbol == c.undefinedSymbol
  }
 diff --git a/internal/compiler/fileloader.go b/internal/compiler/fileloader.go
-index f8d006e92..8f90cd03b 100644
+index f8d006e92..f955c8f53 100644
 --- a/internal/compiler/fileloader.go
 +++ b/internal/compiler/fileloader.go
 @@ -125,7 +125,7 @@ func processAllProgramFiles(
@@ -1487,6 +1487,22 @@ index f8d006e92..8f90cd03b 100644
  	if opts.Tracing != nil {
  		defer opts.Tracing.Push(tracing.PhaseProgram, "processRootFiles", map[string]any{"count": len(rootFiles)}, false)()
  	}
+@@ -590,8 +601,13 @@ func (p *fileLoader) resolveImportsAndModuleAugmentations(t *parseTask) {
+ 
+ 			resolvedFileName := resolvedModule.ResolvedFileName
+ 			isFromNodeModulesSearch := resolvedModule.IsExternalLibraryImport
+-			// Don't treat redirected files as JS files.
+-			isJsFile := !tspath.FileExtensionIsOneOf(resolvedFileName, tspath.SupportedTSExtensionsWithJsonFlat) && p.projectReferenceFileMapper.getRedirectParsedCommandLineForResolution(ast.NewHasFileName(resolvedFileName, p.toPath(resolvedFileName))) == nil
++			// Extra-extension files get their script kind from host registration,
++			// not from the resolved path's suffix. Project-reference redirects
++			// also bypass suffix classification. Exclude both from the JavaScript
++			// file gate.
++			isJsFile := !p.resolver.IsExtraExtensionFile(resolvedFileName) &&
++				!tspath.FileExtensionIsOneOf(resolvedFileName, tspath.SupportedTSExtensionsWithJsonFlat) &&
++				p.projectReferenceFileMapper.getRedirectParsedCommandLineForResolution(ast.NewHasFileName(resolvedFileName, p.toPath(resolvedFileName))) == nil
+ 			isJsFileFromNodeModules := isFromNodeModulesSearch && isJsFile && strings.Contains(resolvedFileName, "/node_modules/")
+ 
+ 			// add file to program only if:
 diff --git a/internal/compiler/program.go b/internal/compiler/program.go
 index 74b2504d9..b3b598571 100644
 --- a/internal/compiler/program.go
@@ -1748,15 +1764,16 @@ index a1923826c..aa562b80d 100644
  	if ast.IsIdentifier(expr) {
  		return expr.Text() == parameterName
 diff --git a/internal/module/resolver.go b/internal/module/resolver.go
-index 52400dc2b..abb2ad858 100644
+index 52400dc2b..5dde0f5a1 100644
 --- a/internal/module/resolver.go
 +++ b/internal/module/resolver.go
-@@ -158,9 +158,18 @@ type Resolver struct {
+@@ -158,9 +158,30 @@ type Resolver struct {
  	compilerOptions *core.CompilerOptions
  	typingsLocation string
  	projectName     string
-+	// extraExtensions are host-registered file extensions (e.g. ".vue") that
-+	// should resolve to the file itself, not just to a ".d.<ext>.ts" declaration.
++	// extraExtensions are normalized suffixes registered through
++	// ExtraFileExtensions. They allow literal host files to resolve after the
++	// declaration probe.
 +	extraExtensions []string
  	// reportDiagnostic: DiagnosticReporter
  }
@@ -1767,26 +1784,42 @@ index 52400dc2b..abb2ad858 100644
 +	r.extraExtensions = extensions
 +}
 +
++// IsExtraExtensionFile reports whether fileName uses an extension registered by
++// SetExtraExtensions.
++func (r *Resolver) IsExtraExtensionFile(fileName string) bool {
++	for _, extension := range r.extraExtensions {
++		if tspath.FileExtensionIs(fileName, extension) {
++			return true
++		}
++	}
++	return false
++}
++
  type ResolverOptions struct {
  	PackageJsonCache *packagejson.InfoCache
  }
-@@ -1558,11 +1567,22 @@ func (r *resolutionState) tryAddingExtensions(extensionless string, extensions e
+@@ -1558,11 +1579,27 @@ func (r *resolutionState) tryAddingExtensions(extensionless string, extensions e
  		}
  		return continueSearching()
  	default:
-+		// An on-disk ".d.<ext>.ts" declaration wins over the extra-extension
-+		// file itself, matching stock TS: the ".d.<ext>.ts" probe is also where
-+		// a Volar host substitutes the SFC when no declaration exists, so trying
-+		// the literal file here lands exactly on stock's fallback order.
++		// Match TypeScript's declaration-first order for an explicit
++		// nonstandard extension: "./Component.vue" probes
++		// "Component.d.vue.ts" before the registered ".vue" file.
  		if extensions&extensionsDeclaration != 0 && !tspath.IsDeclarationFileName(extensionless+originalExtension) {
  			if resolved := r.tryExtension(".d"+originalExtension+".ts", extensionless, false); !resolved.shouldContinueSearching() {
  				return resolved
  			}
  		}
-+		// Host-registered extra extensions (e.g. ".vue") resolve to the file
-+		// itself, standing in for the Volar host's phantom declaration remap.
++		// tsgo cannot invoke the language plugin's module-resolution host, so a
++		// registered extension authorizes the literal host file after the
++		// declaration probe misses.
 +		if originalExtension != "" && slices.Contains(r.resolver.extraExtensions, originalExtension) {
 +			if resolved := r.tryExtension(originalExtension, extensionless, false); !resolved.shouldContinueSearching() {
++				// Keep the host path so the loader applies its registered script
++				// kind. The extension is separate resolution metadata used by
++				// the checker to decide whether the import is typed; classify it
++				// as TypeScript so the host suffix does not trigger TS7016.
++				resolved.extension = tspath.ExtensionTs
 +				return resolved
 +			}
 +		}

--- a/patches/typescript/overlay/src/compiler/tsgoChecker.ts
+++ b/patches/typescript/overlay/src/compiler/tsgoChecker.ts
@@ -4011,12 +4011,23 @@ function extensionFromPathOrTs(fileName: string): any {
     }
     return ts.Extension.Ts;
 }
-/** Extra extensions for tsgo when the project contains non-TS root files (.vue, …). */
+/**
+ * Builds the `extraFileExtensions` field sent with tsgo snapshots.
+ *
+ * `runTsc` advertises language-plugin extensions through
+ * `supportedTSExtensionsFlat`, including extensions used only by imported
+ * files. Scanning `fileNames` registers nonstandard root extensions for hosts
+ * that do not modify that table.
+ */
 function collectExtraFileExtensions(fileNames: Iterable<string>, options: any): any[] | undefined {
     // Explicit opt-out in tsconfig must be respected (tsgo mirrors this).
     if (options?.allowArbitraryExtensions === false) return undefined;
     const builtin = BUILTIN_SCRIPT_EXTENSIONS;
     const exts = new Set<string>();
+    for (const extension of ts.supportedTSExtensionsFlat) {
+        const ext = extension.toLowerCase();
+        if (!builtin.has(ext)) exts.add(ext);
+    }
     for (const fn of fileNames) {
         if (typeof fn !== "string") continue;
         const dot = fn.lastIndexOf(".");

--- a/tools/triage-imported-extra-extension.mjs
+++ b/tools/triage-imported-extra-extension.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Witness for a language-plugin extension discovered only through module
+ * resolution.
+ *
+ * The setup mirrors `runTsc` by adding `.vue` to
+ * `supportedTSExtensionsFlat` before `createProgram`. The config contains only
+ * `main.ts`; `Component.vue` must enter the program through the import and
+ * produce no diagnostics.
+ */
+import { createRequire } from 'node:module';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const ts = require(path.join(repoRoot, 'lib', 'typescript.js'));
+const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'tnb-imported-extra-extension-'));
+const configFile = path.join(fixture, 'tsconfig.json');
+const mainFile = path.join(fixture, 'main.ts');
+const componentFile = path.join(fixture, 'Component.vue');
+
+fs.writeFileSync(mainFile, "import component from './Component.vue';\ncomponent.message;\n");
+fs.writeFileSync(componentFile, "export default { message: 'hello' };\n");
+fs.writeFileSync(configFile, JSON.stringify({
+	compilerOptions: {
+		allowArbitraryExtensions: true,
+		module: 'esnext',
+		moduleResolution: 'bundler',
+		noEmit: true,
+		strict: true,
+	},
+	files: ['main.ts'],
+}));
+
+if (!ts.supportedTSExtensionsFlat.includes('.vue')) {
+	ts.supportedTSExtensionsFlat.push('.vue');
+}
+
+const parsed = ts.getParsedCommandLineOfConfigFile(configFile, {}, ts.sys);
+if (!parsed) {
+	console.error('FAIL: could not parse fixture tsconfig');
+	process.exit(1);
+}
+
+const program = ts.createProgram(parsed.fileNames, parsed.options);
+const diagnostics = ts.getPreEmitDiagnostics(program);
+const hasComponent = program.getSourceFiles().some(file => path.resolve(file.fileName) === componentFile);
+
+if (diagnostics.length || !hasComponent) {
+	console.error(`FAIL: imported .vue was not fully loaded (program member: ${hasComponent})`);
+	for (const diagnostic of diagnostics) {
+		console.error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'));
+	}
+	process.exit(1);
+}
+
+console.log('PASS: imported .vue joined the program without being a configured root');


### PR DESCRIPTION
Authored with Codex, gpt-5.6-sol xhigh.

Fixes #31

## Summary

  Language-plugin files such as `.vue` can now enter a tsgo program solely through module resolution. They no
  longer require an explicit `src/**/*.vue` entry in `include`.

  ## Root cause

  TNB derived `extraFileExtensions` only from configured root filenames. Extensions registered by `vue-tsc`
  through `supportedTSExtensionsFlat` were therefore omitted when every matching file was dependency-only.

  The Go resolver also lacked the registered extensions needed to resolve the literal host file after the
  `.d.<ext>.ts` declaration probe. Once resolved, its nonstandard suffix caused the loader to classify it as
  JavaScript and exclude it when `allowJs` was disabled.

  ## Changes

  - Include runtime-registered extensions from `supportedTSExtensionsFlat` in the tsgo snapshot.
  - Register extra extensions with the Go module resolver.
  - Preserve declaration-first resolution: `Component.d.vue.ts` takes precedence over `Component.vue`.
  - Resolve the literal host file when the declaration probe misses.
  - Retain the host path and registered script kind while classifying its resolution metadata as TypeScript.
  - Exclude registered extra-extension files from suffix-based JavaScript gating.
  - Add an imported-only `.vue` regression witness.

  ## Verification

  - `node tools/triage-imported-extra-extension.mjs`
  - Original `vue-tsc --build` reproduction without `src/**/*.vue`
  - `npm run check:lib`
  - `npm run check:enums`
  - `npm run check:sourcefile-guard`
    - `totalRpc=2759`
    - `getSourceFileRpc=1`
    - baseline `<=240`
  - Go module and compiler tests
  - `node tools/triage-nuxtui-exportstar.mjs`