### PR TITLE
fix(tools): sync lockfile after version bump

### DIFF
--- a/tools/bump-version.mjs
+++ b/tools/bump-version.mjs
@@ -64,5 +64,6 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
 		const updated = raw.replace(/("version"\s*:\s*")[^"]*(")/, `$1${next}$2`);
 		if (updated === raw) throw new Error('failed to locate version field in package.json');
 		fs.writeFileSync(PKG, updated);
+		execFileSync('npm', ['i'], { cwd: REPO, stdio: 'inherit' });
 	}
 }


### PR DESCRIPTION
Runs `npm i` after updating `package.json` so npm synchronizes `package-lock.json`.

---

*This pull request was created with assistance from a code agent.*