### PR TITLE
fix(package): exclude source maps from the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"bin",
 		"lib",
 		"vendor",
-		"NOTICE"
+		"NOTICE",
+		"!**/*.map"
 	],
 	"scripts": {
 		"setup": "git submodule update --init && npm run build:js && npm run build:bridge && npm run build:ts",


### PR DESCRIPTION
Excluding source maps reduces the bundle size by 9,134,590 bytes (25.2%).

---

*This pull request was created with assistance from a code agent.*
