### PR TITLE
test(witness): fix issue #55 fixture path

### DIFF
--- a/tools/triage-completion-span-i55.mjs
+++ b/tools/triage-completion-span-i55.mjs
@@ -35,7 +35,7 @@ mk('tsconfig.json', JSON.stringify({
 }));
 mk('first/tsconfig.json', JSON.stringify({
 	compilerOptions: { composite: true, types: ['node'] },
-	include: ['../repro.ts', './.secondary/empty.d.ts'],
+	include: ['../repro.ts', '../.secondary/empty.d.ts'],
 }));
 mk('.secondary/tsconfig.json', JSON.stringify({
 	compilerOptions: { composite: true, types: ['node'] },


### PR DESCRIPTION
Correct `first/tsconfig.json` in the issue #55 witness to include the shared root `.secondary/empty.d.ts`.

---

*This pull request was created with assistance from a code agent.*