### PR TITLE
fix(bridge): preserve auto-import symbol identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
 
       # tools/ci-witness-groups.mjs is the single source of truth for the
       # witness matrix — it validates the table (dupes, missing scripts,
-      # count, orphans, ownership, baselines) on every run, so a bad edit
-      # fails here before the witness jobs spawn.
+      # count) on every run, so a bad edit fails here before six jobs spawn.
       - id: groups
         run: echo "matrix=$(node tools/ci-witness-groups.mjs matrix)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
 
       # tools/ci-witness-groups.mjs is the single source of truth for the
       # witness matrix — it validates the table (dupes, missing scripts,
-      # count) on every run, so a bad edit fails here before six jobs spawn.
+      # count, orphans, ownership, baselines) on every run, so a bad edit
+      # fails here before the witness jobs spawn.
       - id: groups
         run: echo "matrix=$(node tools/ci-witness-groups.mjs matrix)" >> "$GITHUB_OUTPUT"
 

--- a/patches/typescript/0001-tsgo-hooks.patch
+++ b/patches/typescript/0001-tsgo-hooks.patch
@@ -609,7 +609,7 @@ index 6034c9dfc3..0c9a6178db 100644
      let computedWithoutCacheCount = 0;
      const fixes = flatMap(exportInfo, (exportInfo, i) => {
 diff --git a/src/services/completions.ts b/src/services/completions.ts
-index 28d29136da..e267aa7847 100644
+index 28d29136da..b15f4b0ea5 100644
 --- a/src/services/completions.ts
 +++ b/src/services/completions.ts
 @@ -175,6 +175,7 @@ import {
@@ -964,7 +964,7 @@ index 28d29136da..e267aa7847 100644
          symbolToOriginInfoMap[symbols.length] = origin;
          symbolToSortTextMap[symbolId] = importStatementCompletion ? SortText.LocationPriority : SortText.AutoImportSuggestions;
          symbols.push(symbol);
-@@ -5383,7 +5511,7 @@ function getAutoImportSymbolFromCompletionEntryData(name: string, data: Completi
+@@ -5383,19 +5511,34 @@ function getAutoImportSymbolFromCompletionEntryData(name: string, data: Completi
      const containingProgram = data.isPackageJsonImport ? host.getPackageJsonAutoImportProvider!()! : program;
      const checker = containingProgram.getTypeChecker();
      const moduleSymbol = data.ambientModuleName ? checker.tryFindAmbientModule(data.ambientModuleName) :
@@ -973,7 +973,20 @@ index 28d29136da..e267aa7847 100644
          undefined;
  
      if (!moduleSymbol) return undefined;
-@@ -5396,6 +5524,16 @@ function getAutoImportSymbolFromCompletionEntryData(name: string, data: Completi
+-    let symbol = data.exportName === InternalSymbolName.ExportEquals
+-        ? checker.resolveExternalModuleSymbol(moduleSymbol)
+-        : checker.tryGetMemberInModuleExportsAndProperties(data.exportName, moduleSymbol);
++    const getBridgeExport = (checker as unknown as {
++        getExportForCompletionEntryData?: (exportName: string, moduleSymbol: Symbol) => Symbol | undefined;
++    }).getExportForCompletionEntryData;
++    let symbol = getBridgeExport
++        ? getBridgeExport(data.exportName, moduleSymbol)
++        : data.exportName === InternalSymbolName.ExportEquals
++            ? checker.resolveExternalModuleSymbol(moduleSymbol)
++            : checker.tryGetMemberInModuleExportsAndProperties(data.exportName, moduleSymbol);
+     if (!symbol) return undefined;
+     const isDefaultExport = data.exportName === InternalSymbolName.Default;
+     symbol = isDefaultExport && getLocalSymbolForExportDefault(symbol) || symbol;
      return { symbol, origin: completionEntryDataToSymbolOriginInfo(data, name, moduleSymbol) };
  }
  
@@ -990,7 +1003,7 @@ index 28d29136da..e267aa7847 100644
  interface CompletionEntryDisplayNameForSymbol {
      readonly name: string;
      readonly needsConvertPropertyAccess: boolean;
-@@ -6089,6 +6227,23 @@ function isDeprecated(symbol: Symbol, checker: TypeChecker) {
+@@ -6089,6 +6232,23 @@ function isDeprecated(symbol: Symbol, checker: TypeChecker) {
      return !!length(declarations) && every(declarations, isDeprecatedDeclaration);
  }
  

--- a/patches/typescript/0001-tsgo-hooks.patch
+++ b/patches/typescript/0001-tsgo-hooks.patch
@@ -609,7 +609,7 @@ index 6034c9dfc3..0c9a6178db 100644
      let computedWithoutCacheCount = 0;
      const fixes = flatMap(exportInfo, (exportInfo, i) => {
 diff --git a/src/services/completions.ts b/src/services/completions.ts
-index 28d29136da..b15f4b0ea5 100644
+index 28d29136da..48fa363863 100644
 --- a/src/services/completions.ts
 +++ b/src/services/completions.ts
 @@ -175,6 +175,7 @@ import {
@@ -964,46 +964,40 @@ index 28d29136da..b15f4b0ea5 100644
          symbolToOriginInfoMap[symbols.length] = origin;
          symbolToSortTextMap[symbolId] = importStatementCompletion ? SortText.LocationPriority : SortText.AutoImportSuggestions;
          symbols.push(symbol);
-@@ -5383,19 +5511,34 @@ function getAutoImportSymbolFromCompletionEntryData(name: string, data: Completi
+@@ -5382,14 +5510,25 @@ function getRelevantTokens(position: number, sourceFile: SourceFile): { contextT
+ function getAutoImportSymbolFromCompletionEntryData(name: string, data: CompletionEntryData, program: Program, host: LanguageServiceHost): { symbol: Symbol; origin: SymbolOriginInfoExport | SymbolOriginInfoResolvedExport; } | undefined {
      const containingProgram = data.isPackageJsonImport ? host.getPackageJsonAutoImportProvider!()! : program;
      const checker = containingProgram.getTypeChecker();
-     const moduleSymbol = data.ambientModuleName ? checker.tryFindAmbientModule(data.ambientModuleName) :
+-    const moduleSymbol = data.ambientModuleName ? checker.tryFindAmbientModule(data.ambientModuleName) :
 -        data.fileName ? checker.getMergedSymbol(Debug.checkDefined(containingProgram.getSourceFile(data.fileName)).symbol) :
-+        data.fileName ? getModuleSymbolForCompletionEntryData(containingProgram, checker, data.fileName) :
-         undefined;
- 
+-        undefined;
+-
++    const tsgoProgram = containingProgram as Program & {
++        readonly isTsgoBackedProgram: true;
++        getCompletionEntryDataSymbols(fileName: string | undefined, ambientModuleName: string | undefined, exportName: string): { moduleSymbol: Symbol; symbol: Symbol; } | undefined;
++    };
++    let moduleSymbol: Symbol | undefined;
++    let symbol: Symbol | undefined;
++    if (tsgoProgram.isTsgoBackedProgram === true) {
++        const resolved = tsgoProgram.getCompletionEntryDataSymbols(data.fileName, data.ambientModuleName, data.exportName);
++        if (resolved) ({ moduleSymbol, symbol } = resolved);
++    }
++    else {
++        moduleSymbol = data.ambientModuleName ? checker.tryFindAmbientModule(data.ambientModuleName) :
++            data.fileName ? checker.getMergedSymbol(Debug.checkDefined(containingProgram.getSourceFile(data.fileName)).symbol) :
++            undefined;
++        symbol = moduleSymbol && (data.exportName === InternalSymbolName.ExportEquals
++            ? checker.resolveExternalModuleSymbol(moduleSymbol)
++            : checker.tryGetMemberInModuleExportsAndProperties(data.exportName, moduleSymbol));
++    }
      if (!moduleSymbol) return undefined;
 -    let symbol = data.exportName === InternalSymbolName.ExportEquals
 -        ? checker.resolveExternalModuleSymbol(moduleSymbol)
 -        : checker.tryGetMemberInModuleExportsAndProperties(data.exportName, moduleSymbol);
-+    const getBridgeExport = (checker as unknown as {
-+        getExportForCompletionEntryData?: (exportName: string, moduleSymbol: Symbol) => Symbol | undefined;
-+    }).getExportForCompletionEntryData;
-+    let symbol = getBridgeExport
-+        ? getBridgeExport(data.exportName, moduleSymbol)
-+        : data.exportName === InternalSymbolName.ExportEquals
-+            ? checker.resolveExternalModuleSymbol(moduleSymbol)
-+            : checker.tryGetMemberInModuleExportsAndProperties(data.exportName, moduleSymbol);
      if (!symbol) return undefined;
      const isDefaultExport = data.exportName === InternalSymbolName.Default;
      symbol = isDefaultExport && getLocalSymbolForExportDefault(symbol) || symbol;
-     return { symbol, origin: completionEntryDataToSymbolOriginInfo(data, name, moduleSymbol) };
- }
- 
-+function getModuleSymbolForCompletionEntryData(program: Program, checker: TypeChecker, fileName: string): Symbol {
-+    const sourceFile = Debug.checkDefined(program.getSourceFile(fileName));
-+    // tsgo-backed programs hand out a host-binder facade for sf.symbol whose
-+    // object identity does not match the registry-proxied symbols inside
-+    // export info maps; resolve through the bridged checker when it can answer
-+    // (absent on stock checkers — falls back to stock behavior).
-+    const forSourceFile = (checker as unknown as { getModuleSymbolForSourceFile?: (sourceFile: SourceFile) => Symbol | undefined; }).getModuleSymbolForSourceFile;
-+    return checker.getMergedSymbol(forSourceFile?.(sourceFile) ?? Debug.checkDefined(sourceFile.symbol));
-+}
-+
- interface CompletionEntryDisplayNameForSymbol {
-     readonly name: string;
-     readonly needsConvertPropertyAccess: boolean;
-@@ -6089,6 +6232,23 @@ function isDeprecated(symbol: Symbol, checker: TypeChecker) {
+@@ -6089,6 +6228,23 @@ function isDeprecated(symbol: Symbol, checker: TypeChecker) {
      return !!length(declarations) && every(declarations, isDeprecatedDeclaration);
  }
  

--- a/patches/typescript/overlay/src/compiler/tsgoChecker.ts
+++ b/patches/typescript/overlay/src/compiler/tsgoChecker.ts
@@ -8196,6 +8196,18 @@ export function createTsgoProgram(
             return result;
         },
         getTypeChecker: () => checker,
+        // Stock completion details compare these against the batch export map
+        // by object identity, so both symbols stay in the registry domain.
+        getCompletionEntryDataSymbols: (fileName: string | undefined, ambientModuleName: string | undefined, exportName: string) => {
+            const moduleSymbol = ambientModuleName
+                ? checker.tryFindAmbientModule(ambientModuleName)
+                : fileName
+                    ? checker.getModuleSymbolForSourceFile(thinProgram.getSourceFile(fileName))
+                    : undefined;
+            if (!moduleSymbol) return undefined;
+            const symbol = checker.getExportForCompletionEntryData(exportName, moduleSymbol);
+            return symbol ? { moduleSymbol, symbol } : undefined;
+        },
         getConfigFileParsingDiagnostics: () => configDiags,
         getOptionsDiagnostics: () => [],
         getSemanticDiagnostics: (sourceFile?: any) => {

--- a/patches/typescript/overlay/src/compiler/tsgoChecker.ts
+++ b/patches/typescript/overlay/src/compiler/tsgoChecker.ts
@@ -19,7 +19,7 @@
 import * as ts from "./_namespaces/ts.js";
 import { bindSourceFile } from "./binder.js";
 import { createSourceFile } from "./parser.js";
-import { SyntaxKind, SymbolFlags, SymbolFormatFlags, NodeFlags, ModifierFlags, JSDocParsingMode, ModuleKind, StructureIsReused, EmitHint, EmitFlags, type Path, type Program, type TypeChecker } from "./types.js";
+import { SyntaxKind, SymbolFlags, SymbolFormatFlags, NodeFlags, ModifierFlags, JSDocParsingMode, ModuleKind, StructureIsReused, EmitHint, EmitFlags, InternalSymbolName, type Path, type Program, type TypeChecker } from "./types.js";
 import { getBuildInfoText, getTsBuildInfoEmitOutputFilePath, createPrinterWithRemoveComments } from "./emitter.js";
 import { usingSingleLineStringWriter, canHaveJSDoc } from "./utilities.js";
 import { getParseTreeNode, isFunctionLike } from "./utilitiesPublic.js";
@@ -10867,10 +10867,10 @@ export function createTsgoChecker(program: any): any {
         return true;
     }
 
-    function tryGetMemberInModuleExportsImpl(memberName: any, moduleSymbol: any): any {
+    function getMemberInModuleExportsRaw(memberName: any, moduleSymbol: any): any {
         if (moduleSymbol?.exports) {
             const sym = moduleSymbol.exports.get(memberName);
-            if (sym) return refineNavSymbol(sym);
+            if (sym) return sym;
             // Fall through on miss: the raw host table holds direct members only,
             // while stock's getExportsOfModule (checker.ts:5155) also resolves
             // `export *` chains — let the Go side answer those. Returning
@@ -10881,12 +10881,16 @@ export function createTsgoChecker(program: any): any {
         }
         ensureProject();
         try {
-            return refineNavSymbol(rpc().getMemberInModuleExports(moduleSymbol, memberName));
+            return rpc().getMemberInModuleExports(moduleSymbol, memberName);
         } catch { return undefined; }
     }
 
-    function tryGetMemberInModuleExportsAndPropertiesImpl(memberName: any, moduleSymbol: any): any {
-        const symbol = tryGetMemberInModuleExportsImpl(memberName, moduleSymbol);
+    function tryGetMemberInModuleExportsImpl(memberName: any, moduleSymbol: any): any {
+        return refineNavSymbol(getMemberInModuleExportsRaw(memberName, moduleSymbol));
+    }
+
+    function getMemberInModuleExportsAndPropertiesRaw(memberName: any, moduleSymbol: any): any {
+        const symbol = getMemberInModuleExportsRaw(memberName, moduleSymbol);
         if (symbol) return symbol;
 
         ensureProject();
@@ -10897,7 +10901,11 @@ export function createTsgoChecker(program: any): any {
         const exportEqualsType = getTypeOfSymbolForExportEquals(exportEquals);
         if (!exportEqualsType || !shouldTreatPropertiesOfExternalModuleAsExports(exportEqualsType)) return undefined;
 
-        return refineNavSymbol(resolvePropertyOfType(exportEqualsType, memberName));
+        return resolvePropertyOfType(exportEqualsType, memberName);
+    }
+
+    function tryGetMemberInModuleExportsAndPropertiesImpl(memberName: any, moduleSymbol: any): any {
+        return refineNavSymbol(getMemberInModuleExportsAndPropertiesRaw(memberName, moduleSymbol));
     }
 
     function getSymbolFlagsImpl(symbol: any, excludeLocalMeanings?: boolean): number {
@@ -13079,6 +13087,13 @@ export function createTsgoChecker(program: any): any {
         },
         tryGetMemberInModuleExportsAndProperties(memberName: any, moduleSymbol: any): any {
             return tryGetMemberInModuleExportsAndPropertiesImpl(memberName, moduleSymbol);
+        },
+        // Completion details match this result against the batch export map by
+        // object identity; navigation remapping would replace the registry symbol.
+        getExportForCompletionEntryData(exportName: any, moduleSymbol: any): any {
+            return exportName === InternalSymbolName.ExportEquals
+                ? resolveExternalModuleSymbolImpl(moduleSymbol)
+                : getMemberInModuleExportsAndPropertiesRaw(exportName, moduleSymbol);
         },
         resolveExternalModuleSymbol(moduleSymbol: any): any {
             return refineNavSymbol(resolveExternalModuleSymbolImpl(moduleSymbol));

--- a/tools/ci-witness-groups.mjs
+++ b/tools/ci-witness-groups.mjs
@@ -14,7 +14,7 @@
 // parent-watch-acceptance / rpcsym-adversarial all run ≤1s; the real cost is
 // nine ~49-70s witnesses): each of wg1-wg4 carries two heavies (~126-131s),
 // wg5 carries the ninth plus all ≤11s witnesses (~125s). Rebalance by moving
-// names between lists; every invocation validates the full table (below).
+// names between lists; `all` validates the full table (below).
 //
 // 2026-08-03 convergence audit: 14 witnesses wired (13 in the audit, plus
 // triage-nuxtui-exportstar 2026-08-04 — unblocked by the bin symlink the
@@ -171,29 +171,10 @@ const toolsDir = path.dirname(fileURLToPath(import.meta.url));
 const flat = groups.flatMap(g => g.witnesses);
 const dupes = flat.filter((w, i) => flat.indexOf(w) !== i);
 const missing = flat.filter(w => !fs.existsSync(path.join(toolsDir, `${w}.mjs`)));
-const onDisk = fs.readdirSync(toolsDir)
-	.filter(f => f.startsWith('triage-') && f.endsWith('.mjs'))
-	.map(f => f.slice(0, -'.mjs'.length));
-const accounted = new Set([...flat, ...LOCAL_ONLY, ...OWNED_ELSEWHERE]);
-const orphans = onDisk.filter(w => !accounted.has(w));
-const missingLocal = [...LOCAL_ONLY, ...OWNED_ELSEWHERE].filter(w => !fs.existsSync(path.join(toolsDir, `${w}.mjs`)));
-const baselineDir = path.join(toolsDir, 'baselines');
-const groupSet = new Set(flat);
-const unwired = fs.existsSync(baselineDir)
-	? fs.readdirSync(baselineDir)
-		.filter(f => f.endsWith('.json') && f.startsWith('triage-'))
-		.map(f => f.slice(0, -'.json'.length))
-		.filter(w => !groupSet.has(w))
-	: [];
-const errors = [];
-if (dupes.length) errors.push(`duplicate witnesses: ${[...new Set(dupes)].join(', ')}`);
-if (missing.length) errors.push(`no tools/<name>.mjs for: ${missing.join(', ')}`);
-if (flat.length !== TOTAL) errors.push(`witness count ${flat.length} != TOTAL ${TOTAL} — update the table and TOTAL together`);
-if (orphans.length) errors.push(`orphan triage-*.mjs (no group, not local-only, not owned elsewhere): ${orphans.join(', ')}`);
-if (missingLocal.length) errors.push(`no tools/<name>.mjs for: ${missingLocal.join(', ')}`);
-if (unwired.length) errors.push(`baseline json without a wired witness: ${unwired.map(w => `${w}.json`).join(', ')}`);
-if (errors.length) {
-	for (const error of errors) console.error(error);
+if (dupes.length || missing.length || flat.length !== TOTAL) {
+	if (dupes.length) console.error(`duplicate witnesses: ${[...new Set(dupes)].join(', ')}`);
+	if (missing.length) console.error(`no tools/<name>.mjs for: ${missing.join(', ')}`);
+	if (flat.length !== TOTAL) console.error(`witness count ${flat.length} != TOTAL ${TOTAL} — update the table and TOTAL together`);
 	process.exit(1);
 }
 
@@ -219,5 +200,39 @@ if (arg === 'matrix') {
 		for (const w of g.witnesses) console.log(`  ${w}`);
 	});
 	console.log(`total: ${flat.length} witnesses in ${groups.length} groups`);
+
+	// Orphan sweep: every tools/triage-*.mjs must be in a group, LOCAL_ONLY,
+	// or OWNED_ELSEWHERE. LOCAL_ONLY/OWNED_ELSEWHERE names must exist on
+	// disk. tools/baselines/triage-<name>.json must map to a wired witness
+	// (reverse direction — a group witness without a baseline — is fine).
+	const errors = [];
+	const onDisk = fs.readdirSync(toolsDir)
+		.filter(f => f.startsWith('triage-') && f.endsWith('.mjs'))
+		.map(f => f.slice(0, -'.mjs'.length));
+	const accounted = new Set([...flat, ...LOCAL_ONLY, ...OWNED_ELSEWHERE]);
+	const orphans = onDisk.filter(w => !accounted.has(w));
+	if (orphans.length) {
+		errors.push(`orphan triage-*.mjs (no group, not local-only, not owned elsewhere): ${orphans.join(', ')}`);
+	}
+	const missingLocal = [...LOCAL_ONLY, ...OWNED_ELSEWHERE].filter(w => !fs.existsSync(path.join(toolsDir, `${w}.mjs`)));
+	if (missingLocal.length) {
+		errors.push(`no tools/<name>.mjs for: ${missingLocal.join(', ')}`);
+	}
+	const baselineDir = path.join(toolsDir, 'baselines');
+	if (fs.existsSync(baselineDir)) {
+		const groupSet = new Set(flat);
+		const unwired = fs.readdirSync(baselineDir)
+			.filter(f => f.endsWith('.json') && f.startsWith('triage-'))
+			.map(f => f.slice(0, -'.json'.length))
+			.filter(w => !groupSet.has(w));
+		if (unwired.length) {
+			errors.push(`baseline json without a wired witness: ${unwired.map(w => `${w}.json`).join(', ')}`);
+		}
+	}
+
+	if (errors.length) {
+		for (const e of errors) console.error(e);
+		process.exit(1);
+	}
 	console.log(`local-only (${LOCAL_ONLY.length}) and owned-elsewhere (${OWNED_ELSEWHERE.length}) files all present; ${onDisk.length} triage-*.mjs accounted, no orphans; baselines all wired`);
 }

--- a/tools/ci-witness-groups.mjs
+++ b/tools/ci-witness-groups.mjs
@@ -14,7 +14,7 @@
 // parent-watch-acceptance / rpcsym-adversarial all run ≤1s; the real cost is
 // nine ~49-70s witnesses): each of wg1-wg4 carries two heavies (~126-131s),
 // wg5 carries the ninth plus all ≤11s witnesses (~125s). Rebalance by moving
-// names between lists; `all` validates the full table (below).
+// names between lists; every invocation validates the full table (below).
 //
 // 2026-08-03 convergence audit: 14 witnesses wired (13 in the audit, plus
 // triage-nuxtui-exportstar 2026-08-04 — unblocked by the bin symlink the
@@ -40,7 +40,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const TOTAL = 70;
+const TOTAL = 71;
 
 // Witnesses intentionally NOT in the matrix — run on demand (reasons above).
 const LOCAL_ONLY = [
@@ -137,6 +137,7 @@ const groups = [
 			'check-readme-ledger',
 			'triage-overlay-delta-sync',
 			'triage-completion-details-array',
+			'triage-local-autoimport-details',
 			'triage-alias-self-loop',
 			'triage-alias-nil',
 			'triage-empty-literal',
@@ -170,10 +171,29 @@ const toolsDir = path.dirname(fileURLToPath(import.meta.url));
 const flat = groups.flatMap(g => g.witnesses);
 const dupes = flat.filter((w, i) => flat.indexOf(w) !== i);
 const missing = flat.filter(w => !fs.existsSync(path.join(toolsDir, `${w}.mjs`)));
-if (dupes.length || missing.length || flat.length !== TOTAL) {
-	if (dupes.length) console.error(`duplicate witnesses: ${[...new Set(dupes)].join(', ')}`);
-	if (missing.length) console.error(`no tools/<name>.mjs for: ${missing.join(', ')}`);
-	if (flat.length !== TOTAL) console.error(`witness count ${flat.length} != TOTAL ${TOTAL} — update the table and TOTAL together`);
+const onDisk = fs.readdirSync(toolsDir)
+	.filter(f => f.startsWith('triage-') && f.endsWith('.mjs'))
+	.map(f => f.slice(0, -'.mjs'.length));
+const accounted = new Set([...flat, ...LOCAL_ONLY, ...OWNED_ELSEWHERE]);
+const orphans = onDisk.filter(w => !accounted.has(w));
+const missingLocal = [...LOCAL_ONLY, ...OWNED_ELSEWHERE].filter(w => !fs.existsSync(path.join(toolsDir, `${w}.mjs`)));
+const baselineDir = path.join(toolsDir, 'baselines');
+const groupSet = new Set(flat);
+const unwired = fs.existsSync(baselineDir)
+	? fs.readdirSync(baselineDir)
+		.filter(f => f.endsWith('.json') && f.startsWith('triage-'))
+		.map(f => f.slice(0, -'.json'.length))
+		.filter(w => !groupSet.has(w))
+	: [];
+const errors = [];
+if (dupes.length) errors.push(`duplicate witnesses: ${[...new Set(dupes)].join(', ')}`);
+if (missing.length) errors.push(`no tools/<name>.mjs for: ${missing.join(', ')}`);
+if (flat.length !== TOTAL) errors.push(`witness count ${flat.length} != TOTAL ${TOTAL} — update the table and TOTAL together`);
+if (orphans.length) errors.push(`orphan triage-*.mjs (no group, not local-only, not owned elsewhere): ${orphans.join(', ')}`);
+if (missingLocal.length) errors.push(`no tools/<name>.mjs for: ${missingLocal.join(', ')}`);
+if (unwired.length) errors.push(`baseline json without a wired witness: ${unwired.map(w => `${w}.json`).join(', ')}`);
+if (errors.length) {
+	for (const error of errors) console.error(error);
 	process.exit(1);
 }
 
@@ -199,39 +219,5 @@ if (arg === 'matrix') {
 		for (const w of g.witnesses) console.log(`  ${w}`);
 	});
 	console.log(`total: ${flat.length} witnesses in ${groups.length} groups`);
-
-	// Orphan sweep: every tools/triage-*.mjs must be in a group, LOCAL_ONLY,
-	// or OWNED_ELSEWHERE. LOCAL_ONLY/OWNED_ELSEWHERE names must exist on
-	// disk. tools/baselines/triage-<name>.json must map to a wired witness
-	// (reverse direction — a group witness without a baseline — is fine).
-	const errors = [];
-	const onDisk = fs.readdirSync(toolsDir)
-		.filter(f => f.startsWith('triage-') && f.endsWith('.mjs'))
-		.map(f => f.slice(0, -'.mjs'.length));
-	const accounted = new Set([...flat, ...LOCAL_ONLY, ...OWNED_ELSEWHERE]);
-	const orphans = onDisk.filter(w => !accounted.has(w));
-	if (orphans.length) {
-		errors.push(`orphan triage-*.mjs (no group, not local-only, not owned elsewhere): ${orphans.join(', ')}`);
-	}
-	const missingLocal = [...LOCAL_ONLY, ...OWNED_ELSEWHERE].filter(w => !fs.existsSync(path.join(toolsDir, `${w}.mjs`)));
-	if (missingLocal.length) {
-		errors.push(`no tools/<name>.mjs for: ${missingLocal.join(', ')}`);
-	}
-	const baselineDir = path.join(toolsDir, 'baselines');
-	if (fs.existsSync(baselineDir)) {
-		const groupSet = new Set(flat);
-		const unwired = fs.readdirSync(baselineDir)
-			.filter(f => f.endsWith('.json') && f.startsWith('triage-'))
-			.map(f => f.slice(0, -'.json'.length))
-			.filter(w => !groupSet.has(w));
-		if (unwired.length) {
-			errors.push(`baseline json without a wired witness: ${unwired.map(w => `${w}.json`).join(', ')}`);
-		}
-	}
-
-	if (errors.length) {
-		for (const e of errors) console.error(e);
-		process.exit(1);
-	}
 	console.log(`local-only (${LOCAL_ONLY.length}) and owned-elsewhere (${OWNED_ELSEWHERE.length}) files all present; ${onDisk.length} triage-*.mjs accounted, no orphans; baselines all wired`);
 }

--- a/tools/triage-local-autoimport-details.mjs
+++ b/tools/triage-local-autoimport-details.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Issue #58: a project-local auto-import completion must resolve to an import
+ * edit when its entry data is sent back through completionEntryDetails.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tnbHarnessEnv, withTsserver } from './tsserver-harness.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tsserverPath = path.join(repoRoot, 'lib', 'tsserver.js');
+const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'tnb-local-autoimport-'));
+const main = path.join(fixture, 'src', 'main.ts');
+const model = path.join(fixture, 'src', 'model.ts');
+
+fs.mkdirSync(path.dirname(main), { recursive: true });
+fs.writeFileSync(path.join(fixture, 'tsconfig.json'), JSON.stringify({ include: ['./src/*.ts'] }));
+fs.writeFileSync(main, 'ReadRecordModel;\n');
+fs.writeFileSync(model, 'export const ReadRecordModel = {};\n');
+
+try {
+	const result = await withTsserver({
+		tsserverPath,
+		args: ['--disableAutomaticTypingAcquisition', '--suppressDiagnosticEvents'],
+		env: tnbHarnessEnv(),
+	}, async ({ send }) => {
+		await send('configure', {
+			preferences: {
+				includeCompletionsForModuleExports: true,
+				includeCompletionsWithInsertText: true,
+			},
+		});
+		await send('updateOpen', {
+			changedFiles: [],
+			closedFiles: [],
+			openFiles: [{ file: main, fileContent: 'ReadRecordModel;\n', projectRootPath: fixture }],
+		});
+
+		const completion = await send('completionInfo', {
+			file: main,
+			line: 1,
+			offset: 16,
+			includeExternalModuleExports: true,
+			includeInsertTextCompletions: true,
+		});
+		const entry = completion.body?.entries?.find(candidate => candidate.name === 'ReadRecordModel' && candidate.source === './model');
+		if (!entry) throw new Error('completionInfo did not return ReadRecordModel from ./model');
+
+		const details = await send('completionEntryDetails', {
+			file: main,
+			line: 1,
+			offset: 16,
+			entryNames: [{ name: entry.name, source: entry.source, data: entry.data }],
+		});
+		if (!details.success) throw new Error(details.message || 'completionEntryDetails failed');
+		const changes = details.body?.[0]?.codeActions?.flatMap(action => action.changes ?? []) ?? [];
+		const importEdit = changes
+			.filter(change => change.fileName === main)
+			.flatMap(change => change.textChanges ?? [])
+			.find(change => change.newText.includes('ReadRecordModel') && change.newText.includes('./model'));
+		if (!importEdit) throw new Error('completionEntryDetails returned no ./model import edit');
+		return { data: entry.data, edit: importEdit.newText };
+	});
+	console.log(`ok project-local auto-import details: ${JSON.stringify(result)}`);
+}
+finally {
+	fs.rmSync(fixture, { recursive: true, force: true });
+}
+process.exit(0);


### PR DESCRIPTION
part of #58

Add a required `getCompletionEntryDataSymbols` contract to `isTsgoBackedProgram` programs and split raw export lookup from `refineNavSymbol`, allowing `completionEntryDetails` to recover registry-domain module and export objects without changing ordinary navigation or the stock TypeScript path.

---

*This pull request was created with assistance from a code agent.*
